### PR TITLE
add eslint as git workflow on push and pull request

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -1,0 +1,34 @@
+name: ES Lint Check
+
+on: [push, pull_request]
+
+jobs:
+  eslint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Go to Javacript dir
+        run: cd javascript
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+
+      - name: Install ES Lint
+        run: npm install -g eslint
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v40
+
+      - name: Run ES Lint on all changed files
+        run: |
+          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+            if [[ $file == *.js  ]]; then
+                eslint $file
+            fi
+          done
+

--- a/javascript/.eslintrc.yml
+++ b/javascript/.eslintrc.yml
@@ -1,0 +1,8 @@
+env:
+  browser: true
+  commonjs: true
+  es2021: true
+extends: standard
+parserOptions:
+  ecmaVersion: latest
+rules: {}

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -21,6 +21,11 @@
     "uuid": "^9.0.1"
   },
   "devDependencies": {
+    "eslint": "^8.52.0",
+    "eslint-config-standard": "^17.1.0",
+    "eslint-plugin-import": "^2.29.0",
+    "eslint-plugin-n": "^16.2.0",
+    "eslint-plugin-promise": "^6.1.1",
     "jest": "^27.0.6"
   }
 }


### PR DESCRIPTION
Adding the eslint. 

There are too many warnings on existing files. So only running eslint when there is change in a file (committed in push / pull request).
Moving forward if someone work on some file, they can refactor those file to fix eslint warnings. 