### PR TITLE
add npm standard in git workflow

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -1,0 +1,36 @@
+name: Javascript Linter Check
+
+on: [push, pull_request]
+
+defaults:
+  run:
+    shell: bash
+    working-directory: ./javascript
+
+jobs:
+  javascript-standard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+
+      - name: Install Javascript Standard
+        run: npm install standard
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v40
+
+      - name: Run Standard Linter on all changed files
+        run: |
+            for file_full_path in ${{ steps.changed-files.outputs.all_changed_files }}; do
+                if [[ $file_full_path == javascript/*.js  ]]; then
+                    relative_path="${file_full_path#javascript/}"
+                    npx standard $relative_path
+                fi
+            done

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -18,6 +18,7 @@
     "buffer": "^6.0.3",
     "form-data": "^4.0.0",
     "node-fetch": "^2.6.12",
+    "standard": "^17.1.0",
     "uuid": "^9.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Adding npm standard in git workflow.  its will only triggered for changed file.  

Changing example.js result in workflow failure and merge will be disabled.
<img width="1464" alt="image" src="https://github.com/Bagel-DB/Client/assets/33358060/8eb47272-9a44-45d9-a8ac-214c2ec1ca09">

Details are provided in the workflow runner.
<img width="1453" alt="image" src="https://github.com/Bagel-DB/Client/assets/33358060/8822466b-d6f5-4793-a20f-c44f045d7c74">







